### PR TITLE
QoL: add utils for solaris migration

### DIFF
--- a/barbell/src/barbell/server.ts
+++ b/barbell/src/barbell/server.ts
@@ -6,6 +6,7 @@ import bot from "..";
 import { INIT_ACTION_ID, INIT_MODAL_NAME } from "./consts";
 import { Action } from "./bot";
 import { HeaderBlock } from "@slack/web-api";
+import { ChannelType } from "./types/handlerInputs";
 
 const actionsBlocks = [
 	{
@@ -79,7 +80,7 @@ app.post("/slack/events", async ({ body }: { body: any }) => {
 						value: action.value
 					}))?.[0];
 					console.log("BUTTON CLICK", buttonClick)
-					const blocks = await action.run(flattenedInputs, buttonClick)
+					const blocks = await action.run(blockActionsPayload.user.id, blockActionsPayload.view.type, blockActionsPayload.view.type as ChannelType, flattenedInputs, buttonClick)
 					console.log("RENDERING BLOCKS", blocks)
 					if (blockActionsPayload.view.type === 'modal') {
 						await updateModal(blockActionsPayload.view.id, blocks, action.name, "Submit")
@@ -93,7 +94,7 @@ app.post("/slack/events", async ({ body }: { body: any }) => {
 			else {
 				const intendedAction = getActionValue(actionInput)
 				const action = bot.getAction(intendedAction)
-				const blocks = await action.run()
+				const blocks = await action.run(blockActionsPayload.user.id, blockActionsPayload.view.type, blockActionsPayload.view.type as ChannelType)
 				if (blockActionsPayload.view.type === 'modal') {
 					await updateModal(blockActionsPayload.view.id, blocks, action.name, "Submit")
 				}

--- a/barbell/src/barbell/types/handlerInputs.d.ts
+++ b/barbell/src/barbell/types/handlerInputs.d.ts
@@ -1,0 +1,21 @@
+export type ChannelType = 'channel' | 'im' | 'mpim' | 'home' | 'modal'
+
+export type IO = {
+	input: {
+		text: (name: string) => Promise<string>
+		date: (name: string) => Promise<string>
+		button: (name: string, onClick: () => Promise<void>, style?: 'default' | 'primary' | 'danger') => Promise<void>
+		multiSelect: (name: string, value: { name: string, value: string | number | boolean }[]) => Promise<(string | number | boolean)[]>
+	}
+	output: {
+		markdown: (value: string) => Promise<MarkdownOutput>
+	}
+}
+
+export type HandlerInput = {
+	io: IO
+	userId: string
+	// If it's a modal or home page, channelId is the same as channelType
+	channelId: string
+	channelType: ChannelType
+}

--- a/barbell/src/barbell/utils/slack.ts
+++ b/barbell/src/barbell/utils/slack.ts
@@ -72,3 +72,18 @@ export const publishHomeTab = async (user_id: string, blocks: Block[], title: st
 	console.log("Published home tab", blocks);
 	return { status: 200 };
 }
+
+// TODO: Take in InputOutput type instead of Slack blocks
+export const sendMessage = async (blocks: (Block | KnownBlock)[], channel: string, thread_ts?: string, reply_broadcast: boolean = true) => {
+	await client.chat.postMessage({
+		channel: channel,
+		blocks: blocks,
+		...(thread_ts ? { thread_ts: thread_ts } : {}),
+		...(reply_broadcast ? { reply_broadcast: true } : {})
+	} as ChatPostMessageArguments);
+};
+
+export const readChannelMembers = async (channel: string) => {
+	const members = await client.conversations.members({ channel });
+	return members.members;
+}

--- a/barbell/src/consts.ts
+++ b/barbell/src/consts.ts
@@ -1,0 +1,1 @@
+export const ALERTS_CHANNEL_ID = process.env.ALERTS_CHANNEL_ID || ""

--- a/barbell/src/index.ts
+++ b/barbell/src/index.ts
@@ -1,9 +1,11 @@
 import Bot, { Action } from "./barbell/bot";
+import { sendMessage } from "./barbell/utils/slack";
+import { ALERTS_CHANNEL_ID } from "./consts";
 
 const bot = new Bot()
 const newUserAction = new Action({
 	name: "New User",
-	handler: async (io) => {
+	handler: async ({ io }) => {
 		const fname = await io.input.text("Enter your first name")
 		const lname = await io.input.text(`Hi, ${fname}! Enter your last name`)
 		await io.output.markdown(`Welcome to Barbell, ${fname} ${lname}!`)
@@ -22,8 +24,8 @@ bot.defineAction(newUserAction)
 
 const openGarageAction = new Action({
 	name: "Open Garage",
-	handler: async (io) => {
-		await io.output.markdown("Opening garage...")
+	handler: async ({ io, userId, channelId, channelType }) => {
+		await io.output.markdown(`Opening garage... ${userId} ${channelId} ${channelType}`)
 		await io.input.button("Open", async () => {
 			if (Math.random() > 0.5) {
 				await io.output.markdown("Garage opened!")
@@ -31,6 +33,13 @@ const openGarageAction = new Action({
 				await io.output.markdown("Garage failed to open!")
 			}
 		}, 'primary')
+		await sendMessage([{
+			"type": "section",
+			"text": {
+				"type": "mrkdwn",
+				"text": "Test"
+			}
+		}], ALERTS_CHANNEL_ID)
 	}
 })
 bot.defineAction(openGarageAction)


### PR DESCRIPTION
- move `IO` type to `types/`
- added slack utils to read channel members and post message
- added params to action handler to get data points like user ID, channel ID, and channel type